### PR TITLE
Rc/0.0.2

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,6 @@
 [theme]
 base="light"
 primaryColor="#023047"
+
+[runner]
+fastReruns=true

--- a/app/data.py
+++ b/app/data.py
@@ -1,13 +1,27 @@
 import streamlit as st
-import time
 from datetime import datetime, timedelta
 from loguru import logger
 from src.loading.combined_signals import CompleteTimeSeries
 
+class TimeChecker:
+    last_refresh_time = datetime.min  # Initialize with a very old date
+    delay = 45
+
+    @classmethod
+    def check_and_set(cls):
+        now = datetime.now()
+        if now - cls.last_refresh_time > timedelta(minutes=cls.delay):
+            cls.last_refresh_time = now
+            return True
+        return False
+    
+    @classmethod
+    def set(cls, time):
+        cls.last_refresh_time = time
 
 @st.cache_resource
-def load_complete_time_series(refresh_counter: int = 0) -> CompleteTimeSeries:
-    logger.info(f"Loading complete time series with refresh_counter={refresh_counter}")
+def load_complete_time_series(refresh_time: datetime) -> CompleteTimeSeries:
+    logger.info(f"Loading complete time series with refresh_time={refresh_time}")
     return CompleteTimeSeries()
 
 def populate_session_state(cts: CompleteTimeSeries) -> None:
@@ -21,22 +35,15 @@ def populate_session_state(cts: CompleteTimeSeries) -> None:
 
 def initialize_session_state():
     if 'cts' not in st.session_state:
-        logger.info(f"Initializing session state (prexisting keys: {st.session_state.keys()})")
-        cts = load_complete_time_series(refresh_counter=0)
+        if TimeChecker.check_and_set():
+            logger.info("Refreshing data due to time check")
+        last_refresh_time = TimeChecker.last_refresh_time
+        logger.info(f"Initializing session state (last refresh time: {last_refresh_time})")
+        cts = load_complete_time_series(last_refresh_time)
         populate_session_state(cts)
 
 def refresh_session_state():
-    if 'refresh_counter' not in st.session_state:
-        logger.warning("setting refresh counter to 0 as no such key was found in session_State")
-        st.session_state['refresh_counter'] = 0
-
-    st.session_state['refresh_counter'] += 1
-    logger.info(f"Refreshing session state, refresh_counter={st.session_state['refresh_counter']}")
-    cts = load_complete_time_series(st.session_state['refresh_counter'])
+    logger.info("Refreshing session state")
+    TimeChecker.set(time=datetime.now())
+    cts = load_complete_time_series(TimeChecker.last_refresh_time)
     populate_session_state(cts)
-
-def check_and_refresh():
-    if 'last_refresh' in st.session_state:
-        elapsed_time = datetime.now() - st.session_state['last_refresh']
-        if elapsed_time > timedelta(minutes=45):
-            refresh_session_state()

--- a/app/main.py
+++ b/app/main.py
@@ -6,17 +6,16 @@ from src.utils import format_ordinal
 from src.visuals import charts
 from src.stats import observations
 
-
 def main_page():
-    import streamlit as st
     from components.page_config import get_page_config
     from components.header import get_header
     from components.topline_statistics import get_topline_statistics
+
+    print('A', list(st.session_state.keys()))
     
     get_page_config()
     get_header()
     data.initialize_session_state()
-    data.check_and_refresh()
     
     # data
     metrics = st.session_state['main_statistics']

--- a/app/pages/3_trivia.py
+++ b/app/pages/3_trivia.py
@@ -71,7 +71,7 @@ def trivia():
 
     insight.write(f"""
     - Citizens were {verb} {version}
-    - {data_citizens.data['period'].iloc[0]} added a whole **${data_pledges.data['value'].iloc[0]:,.0f}** in new pledges (a pattern that was {pledge_commonality} ({utils.format_ordinal(pledge_percentile)} percentile)
+    - {data_citizens.data['period'].iloc[0]} added a whole **${data_pledges.data['value'].iloc[0]:,.0f}** in new pledges, a pattern that was {pledge_commonality} ({utils.format_ordinal(pledge_percentile)} percentile)
     - This brought the crowdfunding total to ${data_citizens.data['total_pledge'].iloc[0]/1e6:.1f}M.
     - During that day **{data_citizens.data['value'].iloc[0]:,.0f}** new accounts were opened, totalling {data_citizens.data['total_citizens'].iloc[0]:,.0f}. Such a pattern was {citizens_commonality} ({utils.format_ordinal(citizens_percentile)} percentile).
     {add_on}


### PR DESCRIPTION
# Bug fixes

[Fixed] an issue causing data refreshes never to work and the cached instance of `CompleteTimeSeries` to repopulate the app's data.

> Context: it turns out that `st.session_state` always resets upon page refreshes, since for `streamlit` page refreshes create new sessions. Thus, relying on populating a refresh counter was a bad idea (it should have been a server-side variable from the get-go). I introduced a `TimeChecker` class with a `check_and_set` method to decide if the cts-loading function should have its cache invalidated based on a 45-minute time delay (handling re-render and page refreshes). and a `set` method that the refresh button can use to force a data refresh
     